### PR TITLE
Don't run templates in "Preview" mode

### DIFF
--- a/templates/export/Elevar - DataLayer Variable with Validation v.2.tpl
+++ b/templates/export/Elevar - DataLayer Variable with Validation v.2.tpl
@@ -136,6 +136,13 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT"
       }
     ]
+  },
+  {
+    "type": "TEXT",
+    "name": "debugMode",
+    "simpleValueType": true,
+    "defaultValue": "{{Debug Mode}}",
+    "displayName": "Debug Mode Variable"
   }
 ]
 
@@ -313,36 +320,39 @@ const getDataLayerValue = key => {
 
 const validationTable = data.validationTable;
 const valueType = data.valueType;
+const debugMode = data.debugMode;
 const dataLayerValue = getDataLayerValue(data.dataLayerKey);
 
 // Don't validate if item is undefined
 // But add error if item is required
-if (typeof dataLayerValue === 'undefined') {
-  if (data.required === true) {
-    newError(dataLayerValue, 'required', 'true');
-  }
-} else {
-  switch (valueType) {
-    case "value":
-        validateValue(dataLayerValue, validationTable);
-      break;
+if (!debugMode) {
+  if (typeof dataLayerValue === 'undefined') {
+    if (data.required === true) {
+      newError(dataLayerValue, 'required', 'true');
+    }
+  } else {
+    switch (valueType) {
+      case "value":
+          validateValue(dataLayerValue, validationTable);
+        break;
 
-    case 'object':
-      if (getType(dataLayerValue) !== 'object') {
-        newError(dataLayerValue, 'typeOf', 'object');
-      }
-      validateObject(dataLayerValue, validationTable);
-      break;
+      case 'object':
+        if (getType(dataLayerValue) !== 'object') {
+          newError(dataLayerValue, 'typeOf', 'object');
+        }
+        validateObject(dataLayerValue, validationTable);
+        break;
 
-    case 'array': 
-      if (getType(dataLayerValue) !== 'array') {
-        newError(dataLayerValue, 'typeOf', 'array');
-      }
-      validateArray(dataLayerValue, validationTable);
-      break;
+      case 'array': 
+        if (getType(dataLayerValue) !== 'array') {
+          newError(dataLayerValue, 'typeOf', 'array');
+        }
+        validateArray(dataLayerValue, validationTable);
+        break;
 
-    default:
-      break;
+      default:
+        break;
+    }
   }
 }
 

--- a/templates/export/Elevar - Monitoring Template v.2.tpl
+++ b/templates/export/Elevar - Monitoring Template v.2.tpl
@@ -55,6 +55,13 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ]
+  },
+  {
+    "type": "TEXT",
+    "name": "debugMode",
+    "displayName": "Debug Mode Variable",
+    "simpleValueType": true,
+    "defaultValue": "{{Debug Mode}}"
   }
 ]
 
@@ -82,31 +89,33 @@ const getEventName = (eventId, dataLayer) => {
   }, false);
 };
 
-// Fires after all tags for the trigger have completed
-addEventCallback(function(containerId, eventData) {
-  const DATA_LAYER = copyFromWindow(data.dataLayerName ? data.dataLayerName : "dataLayer");
-  const errors = copyFromWindow(VALIDATION_ERRORS);
+if (!data.debugMode) {
+  // Fires after all tags for the trigger have completed
+  addEventCallback(function(containerId, eventData) {
+    const DATA_LAYER = copyFromWindow(data.dataLayerName ? data.dataLayerName : "dataLayer");
+    const errors = copyFromWindow(VALIDATION_ERRORS);
 
-  // This removes the validation errors from window after they have been sent
-  setInWindow(VALIDATION_ERRORS, [], true);
+    // This removes the validation errors from window after they have been sent
+    setInWindow(VALIDATION_ERRORS, [], true);
 
-  // Send Pixel if there are errors
-  if (errors && errors.length > 0) {
-    errors.forEach((errorEvent, index) => {      
-      let url =
-        "https://monitoring.getelevar.com/track.gif?ctid=" +
-        containerId +
-        "&idx=" +
-        index +
-        "&event_name=" +
-        getEventName(errorEvent.eventId, DATA_LAYER) +
-        "&error=" +
-        errorEvent.error.message;
+    // Send Pixel if there are errors
+    if (errors && errors.length > 0) {
+      errors.forEach((errorEvent, index) => {      
+        let url =
+          "https://monitoring.getelevar.com/track.gif?ctid=" +
+          containerId +
+          "&idx=" +
+          index +
+          "&event_name=" +
+          getEventName(errorEvent.eventId, DATA_LAYER) +
+          "&error=" +
+          errorEvent.error.message;
 
-      sendPixel(url);
-    });
-  }
-});
+        sendPixel(url);
+      });
+    }
+  });
+}
 
 data.gtmOnSuccess();
 


### PR DESCRIPTION
Fixes validation and monitoring pixel firing multiple times in "Preview" mode. @twslade should validation be run in "Preview" mode so that errors could be caught before publishing and only stop the monitoring pixel from firing?

Use GTM built-in `Debug Mode` variable to know if the debug mode is currently on. This, unfortunately, adds a new field to the template fields, because I haven't figured out a way to access GTM variables from the code directly without importing them.

