### PR TITLE
Add Pinterest Tag Template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "gtm-monitoring-klaviyo"]
 	path = templates/gtm-monitoring-klaviyo
 	url = https://github.com/getelevar/gtm-monitoring-klaviyo.git
+[submodule "templates/gtm-monitoring-pinterest"]
+	path = templates/gtm-monitoring-pinterest
+	url = https://github.com/getelevar/gtm-monitoring-pinterest.git


### PR DESCRIPTION
part of https://github.com/getelevar/elevar-monorepo/issues/35

**Adds Pinterest template tag**

I added a new account in GTM a while back called `Elevar Monitoring Templates`. It contains a container called `Template Development` and that's where I've been developing the templates. You can take a look at the templates there and preview the code for this template also.

This also contains a bunch of unit tests to verify basic functionality and that the code should work. I haven't tested this on an actual site, but the functionality is the same as for "facebook" and "snapchat" templates so I don't see any issues why it wouldn't work if the Pinterest script is called "pintrk".

The template communicates to the core tag in the exact same way as FB and SC (pushing tag information to an array in the window).

Here's the docs for the Pinterest script: https://help.pinterest.com/en-gb/business/article/base-code.

---

Similar to 'facebook' and 'snapchat', this template does not inject the Pinterest script. It has to be injected on the page for this to work.

One difference to the facebook and snapchat templates is that this injects also the `load` event and it doesn't require a separate tag, whereas the FB and sc tags require another tag for the `load` events.

---

I also included all the required files and setup for the template gallery.