### PR TITLE
Add Criteo Template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "gtm-monitoring-klaviyo"]
 	path = templates/gtm-monitoring-klaviyo
 	url = https://github.com/getelevar/gtm-monitoring-klaviyo.git
+[submodule "templates/gtm-monitoring-criteo"]
+	path = templates/gtm-monitoring-criteo
+	url = https://github.com/getelevar/gtm-monitoring-criteo.git


### PR DESCRIPTION
This mirrors the logic of the GTM built-in OneTag from Criteo. It doesn't support all the events that were available in the Criteo documentation but supports the same events that the GTM built-in one does. The Criteo doc is not the best: https://www.criteo.com/wp-content/uploads/2018/09/CSPOneTag_v1.1.pdf

A lot of the template logic is controlled by how the inputs are rendered on GTM. Some of them have conditions on when they are visible for example depending on the `Page Type` selection. Some of the inputs take only variables and others (like variable names) are always required if they are visible.

I decided that, all variables should be marked as used by the template event even if they are not actually sent. This makes sure that if a variable is not sent because it's `undefined` it's still marked as used by the tag.

The tag does not wait for the Criteo script injection to complete, because the events are pushed to an array queue instead of calling function. So the Criteo tag works in a similar way as the GTM `dataLayer`. This template injects the Criteo script every time a Criteo tag is called, with the account id provided in the tag.

---

I set up the GTM container here and you can trigger a basic Criteo event by typing `criteo` in the input and clicking submit: https://ofqko.csb.app/. It uses the "Template Development" container.

The template is also ready for the template gallery.