### PR TITLE
Add Tag Info template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "gtm-monitoring-klaviyo"]
 	path = templates/gtm-monitoring-klaviyo
 	url = https://github.com/getelevar/gtm-monitoring-klaviyo.git
+[submodule "templates/gtm-monitoring-tag-info"]
+	path = templates/gtm-monitoring-tag-info
+	url = https://github.com/getelevar/gtm-monitoring-tag-info.git


### PR DESCRIPTION
This was built due to the concerns raised in the review process https://github.com/getelevar/gtm-monitoring-core/issues/3#issuecomment-620223849.

This template could replace all channel specific templates. So they could probably be removed if this is used.

**It works by**
1. The user adding additional metadata to normal tags
2. It captures this metadata in the addEventCallback function and saves it to the tag info key in the window.
3. This info is then read by the core template

Users will have to fill in the metadata correctly, so this should have some good documentation on how it should be setup.

---

The google reviewer also noted that they are planning on adding additional Custom Template APIs in the future which might solve some of the pain points we are having with the templates (e.g. having to input variable names).